### PR TITLE
Use forked djia package for https

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "async": "^2.0.1",
     "debug": "^2.2.0",
-    "djia": "^1.2.3",
+    "djia": "github:Lapixx/djia#prebuild",
     "geo-graticule": "^2.0.4",
     "hex-frac-dec-frac": "^1.0.1",
     "lodash": "^4.14.1",


### PR DESCRIPTION
*poof*

sorry sorry, GitHub defaults the base branch to the original repo instead of the fork and I wasn't paying attention when merging ._.
